### PR TITLE
Archive optional cycle curation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ The archiver copies only these cycle files into `airac-data`:
 | `UK_{YYYY}_{NN}.sct` | VATSIM UK sector file for the cycle |
 | `in.json` | Supplementary parser input |
 | `out.json` | Parser output, archived as `out.{ident}.{n}.json` |
+| `curation_notes.md` | Optional manual curation note for cycle-specific row removals or other interventions |
 
-Everything else in the working directory is ignored.
+Everything else in the working directory is ignored. `curation_notes.md` is optional: it is archived when present and ignored when absent.
 
 Expected files that are missing are recorded as warnings in `manifest.md`, but the archiver can still proceed as long as the directory looks like the correct cycle directory.
 

--- a/src/archiver.py
+++ b/src/archiver.py
@@ -32,8 +32,10 @@ directory are silently ignored:
 - UK_{YYYY}_{NN}.sct  — VATSIM UK sector file (hard to re-obtain)
 - in.json             — SRD Parser config input
 - out.json            — SRD Parser output (archived as out.YYNN.n.json)
+- curation_notes.md   — optional cycle-specific manual curation note
 
-Their absence is logged as a warning but does not prevent archiving.
+Only the required files are logged as warnings when absent; the curation note
+is archived when present and ignored when absent.
 
 Concurrency
 -----------
@@ -63,11 +65,22 @@ from src.airac import AiracCycle
 
 _DIR_PREFIX = "vFPC "
 
-# Allowlisted filenames (exact match).  Only these — plus the cycle-specific
-# .sct file — are collected from the working directory.  Everything else is
-# silently ignored.  This is also the expected-files list: their absence
-# triggers a warning in the manifest.
+# Allowlisted filenames (exact match). Only these — plus the cycle-specific
+# .sct file — are collected from the working directory. Everything else is
+# silently ignored.
 _ALLOWED_FIXED = [
+    "Routes.csv",
+    "Notes.csv",
+    "in.json",
+    "out.json",
+    "curation_notes.md",
+]
+
+# Required files that should normally be present for a valid cycle archive.
+# Their absence is recorded as a warning in the manifest. Optional allowlisted
+# files such as curation_notes.md are archived when present but do not warn
+# when absent.
+_EXPECTED_FIXED = [
     "Routes.csv",
     "Notes.csv",
     "in.json",
@@ -160,7 +173,7 @@ def _collect_files(cycle_dir: Path, cycle: AiracCycle) -> tuple[list[Path], list
 
     # Check for expected files and build warnings
     present_names = {p.name for p in all_files}
-    expected = _ALLOWED_FIXED + [_sct_basename(cycle)]
+    expected = _EXPECTED_FIXED + [_sct_basename(cycle)]
     warnings = [name for name in expected if name not in present_names]
 
     # Guard against archiving a wrong or empty directory

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -44,6 +44,10 @@ _ALLOWED_FILES = [
     "UK_2026_02.sct",
 ]
 
+_OPTIONAL_ALLOWED_FILES = [
+    "curation_notes.md",
+]
+
 # Files that should be silently ignored (not on the allowlist).
 _NON_ALLOWED_FILES = [
     "EG-ENR-3.2-en-GB.html",
@@ -70,7 +74,7 @@ def _make_cycle_dir(tmp_path: Path, filenames: list[str]) -> Path:
 
 def _make_full_cycle_dir(tmp_path: Path) -> Path:
     """Create a realistic cycle directory with allowed and non-allowed files."""
-    return _make_cycle_dir(tmp_path, _ALLOWED_FILES + _NON_ALLOWED_FILES)
+    return _make_cycle_dir(tmp_path, _ALLOWED_FILES + _OPTIONAL_ALLOWED_FILES + _NON_ALLOWED_FILES)
 
 
 # ---------------------------------------------------------------------------
@@ -242,7 +246,7 @@ class TestCollectFiles:
         cycle_dir = _make_full_cycle_dir(tmp_path)
         files, _ = _collect_files(cycle_dir, CYCLE_2602)
         names = {p.name for p in files}
-        assert names == set(_ALLOWED_FILES)
+        assert names == set(_ALLOWED_FILES + _OPTIONAL_ALLOWED_FILES)
 
     def test_ignores_non_allowlisted_files(self, tmp_path):
         cycle_dir = _make_full_cycle_dir(tmp_path)
@@ -254,6 +258,13 @@ class TestCollectFiles:
     def test_no_warnings_when_all_expected_present(self, tmp_path):
         cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES)
         _, warnings = _collect_files(cycle_dir, CYCLE_2602)
+        assert warnings == []
+
+    def test_optional_curation_note_does_not_trigger_warning(self, tmp_path):
+        cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES + _OPTIONAL_ALLOWED_FILES)
+        files, warnings = _collect_files(cycle_dir, CYCLE_2602)
+        names = {p.name for p in files}
+        assert "curation_notes.md" in names
         assert warnings == []
 
     def test_warns_on_missing_sct(self, tmp_path):
@@ -498,6 +509,11 @@ class TestArchiveCycle:
                 assert "out.2602.1.json" in names, "out.json must be versioned as out.2602.1.json"
             else:
                 assert name in names
+
+    def test_optional_curation_note_copied_when_present(self, tmp_path):
+        copied, _ = self._run(tmp_path, filenames=_ALLOWED_FILES + _OPTIONAL_ALLOWED_FILES)
+        names = {p.name for p in copied}
+        assert "curation_notes.md" in names
 
     def test_non_allowed_files_not_copied(self, tmp_path):
         cycle_dir = _make_full_cycle_dir(tmp_path)


### PR DESCRIPTION
## Summary
- archive an optional curation_notes.md file when it is present in a cycle working directory
- keep curation_notes.md out of the expected-file warning list so normal cycles do not emit missing-file warnings
- document the new optional archive artifact and cover it with tests

## Why
AIRAC cycles sometimes need manual SRD row removals before rerunning New-SRDParser. When that happens, we need a durable cycle-scoped note explaining what was removed and why. The archiver should preserve that note without treating it as a required file.

## Testing
- pytest tests/test_archiver.py