### PR TITLE
Archive out.json by parser cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Copies prepared AIRAC cycle files into the [airac-data](https://github.com/VFPC/airac-data) archive repo as flat files and stages them for review before commit.
 
-This tool does **not** build zip archives. It copies an allowlisted set of files into `airac-data`, writes `manifest.md`, renames `out.json` to a versioned archive filename, and runs `git add`.
+This tool does **not** build zip archives. It copies an allowlisted set of files into `airac-data`, writes `manifest.md`, renames `out.json` using the parser output `cycle` field, and runs `git add`.
 
 Run this tool after `New-SRDParser` has produced `out.json` in the cycle working directory.
 
@@ -67,8 +67,10 @@ The archiver copies only these cycle files into `airac-data`:
 | `Notes.csv` | SRD notes data |
 | `UK_{YYYY}_{NN}.sct` | VATSIM UK sector file for the cycle |
 | `in.json` | Supplementary parser input |
-| `out.json` | Parser output, archived as `out.{ident}.{n}.json` |
+| `out.json` | Parser output, archived as `out.{cycle}.json` using the embedded parser `cycle` value |
 | `curation_notes.md` | Optional manual curation note for cycle-specific row removals or other interventions |
+| `Routes.*curation*.json`, `Routes.*edits*.json`, `Routes.*curation*.md` | Optional route curation audit files used to reconstruct SRD route patches |
+| `vfp*_curation*.json`, `vfp*_curation*.md` | Optional issue-specific route curation audit files |
 | `aip_airports.json` | Optional AIP airport artifact used by rebuild/evaluation tooling |
 | `aip_airspaces.json` | Optional generated AIP controlled-airspace artifact |
 | `aip_navaids.json` | Optional AIP navaid artifact |
@@ -112,7 +114,7 @@ The `--cycle` argument is a four-digit AIRAC ident: two-digit year followed by t
 1. Validates that the target cycle directory exists.
 2. Collects only the allowlisted files for that cycle.
 3. Copies them as flat files into `{archive_repo}\vFPC YYNN\`.
-4. Renames `out.json` to `out.{ident}.{n}.json`.
+4. Renames `out.json` to `out.{cycle}.json` using the `cycle` value inside `out.json`.
 5. Renames the runtime bundle `manifest.json` to `runtime_bundle_manifest.json` when present.
 6. Writes `manifest.md` with cycle metadata, warnings, and SHA256 checksums.
 7. Runs `git add` in the `airac-data` repo so the archive is staged for review.
@@ -130,20 +132,20 @@ git push
 
 ## Dot releases for out.json
 
-The archive keeps multiple versions of `out.json` for the **same cycle** when that cycle is re-archived.
+The archive keeps multiple published parser outputs for the **same AIRAC cycle** when dot releases are moved to production.
 
 Examples:
 
-- `out.2603.1.json` = first archived parser output for AIRAC 2603
-- `out.2603.2.json` = later re-archive of AIRAC 2603 after a parser rerun or correction
-- `out.2603.3.json` = another later archive of the same cycle
+- `out.2605.6.json` = parser output whose embedded `cycle` is `2605.6`
+- `out.2605.9.json` = later published parser output whose embedded `cycle` is `2605.9`
 
-These are not separate AIRAC cycles and not semantic-version releases. They are archive revisions of the same cycle output.
+These are not separate AIRAC cycles. They are parser dot releases for the same cycle, and the archive can jump from one dot release to a later one because not every parser run is promoted to production.
 
 When the same cycle is archived again:
 
-- existing `out.2603.N.json` files are preserved
-- the new `out.json` becomes the next numbered version
+- existing `out.YYNN.N.json` files are preserved
+- the new `out.json` becomes `out.<embedded-cycle>.json`
+- archiving fails if that filename already exists with different content
 - the manifest lists every archived version currently present for that cycle
 
 ---

--- a/src/archiver.py
+++ b/src/archiver.py
@@ -12,15 +12,15 @@ Workflow
 Archive layout in airac-data repo
 ----------------------------------
 ``{archive_repo}/vFPC YYNN/<filename>``             — one flat file per collected file
-``{archive_repo}/vFPC YYNN/out.YYNN.{n}.json``      — versioned parser output
+``{archive_repo}/vFPC YYNN/out.<cycle>.json``       - parser output named from out.json
 ``{archive_repo}/vFPC YYNN/manifest.md``             — cycle metadata + checksums
 
 Versioned out.json
 -------------------
 The parser writes ``out.json`` into the working directory.  During archival
-this file is renamed to ``out.{ident}.{n}.json`` (e.g. ``out.2603.1.json``).
-Re-archiving the same cycle increments *n*, and all previous versions are
-preserved.  The manifest lists every version.
+this file is renamed from its embedded ``cycle`` value (e.g. ``2605.9`` becomes
+``out.2605.9.json``). Not every parser dot release is moved to production, so
+archive filenames follow the parser output instead of local archive sequence.
 
 Allowlisted files
 ------------------
@@ -31,8 +31,10 @@ directory are silently ignored:
 - Notes.csv           — SRD notes data (hard to re-obtain)
 - UK_{YYYY}_{NN}.sct  — VATSIM UK sector file (hard to re-obtain)
 - in.json             — SRD Parser config input
-- out.json            — SRD Parser output (archived as out.YYNN.n.json)
-- curation_notes.md   — optional cycle-specific manual curation note
+- out.json            - SRD Parser output (archived as out.<cycle>.json)
+- curation_notes.md   - optional cycle-specific manual curation note
+- Routes.*curation/edits*.json|md and vfp*_curation*.json|md
+                       - optional route patch reconstruction evidence
 - aip_*.json / enr44_points.json — optional AIP rebuild artifacts
 - runtime_rules.json and bundle fact/index files — optional RAD runtime artifacts
 - manifest.json      — optional runtime bundle manifest, archived as
@@ -54,6 +56,7 @@ from __future__ import annotations
 
 import getpass
 import hashlib
+import json
 import re
 import shutil
 import subprocess
@@ -112,10 +115,15 @@ _EXPECTED_FIXED = [
 # Fewer than this indicates a missing or wrong cycle directory, not just an incomplete cycle.
 _MIN_EXPECTED_PRESENT = 3
 
-# Versioned out.json: out.{ident}.{n}.json — e.g. out.2603.1.json
-_OUT_VERSION_RE = re.compile(r"^out\.(\d{4})\.(\d+)\.json$")
+# Versioned out.json: out.{cycle}.json — e.g. out.2605.9.json
+_OUT_VERSION_RE = re.compile(r"^out\.(\d{4})(?:\.(\d+))?\.json$")
+_OUT_CYCLE_RE = re.compile(r"^\d{4}(?:\.\d+)?$")
 _ARCHIVE_DIR_RE = re.compile(r"^vFPC (\d{4})$")
 _SCT_RE = re.compile(r"^UK_\d{4}_\d{2}\.sct$")
+_CURATION_AUDIT_RE = re.compile(
+    r"^(?:Routes\..*(?:curation|edits).*|vfp\d+_.*curation.*)\.(?:json|md)$",
+    re.IGNORECASE,
+)
 
 _SLIM_DROP_FIXED = {
     "Routes.csv",
@@ -157,13 +165,15 @@ def _sct_basename(cycle: AiracCycle) -> str:
     return f"UK_{cycle.year}_{cycle.number:02d}.sct"
 
 
-def _out_version_name(cycle: AiracCycle, n: int) -> str:
-    """Return the versioned filename for out.json: ``out.{ident}.{n}.json``."""
-    return f"out.{cycle.ident}.{n}.json"
+def _out_version_name(cycle_value: str) -> str:
+    """Return the archived filename for an out.json cycle value."""
+    if not _OUT_CYCLE_RE.match(cycle_value):
+        raise ArchiverError(f"Invalid out.json cycle value: {cycle_value!r}")
+    return f"out.{cycle_value}.json"
 
 
 def _existing_out_versions(directory: Path, cycle: AiracCycle) -> list[Path]:
-    """Return all ``out.{ident}.{n}.json`` files in *directory*, sorted by version."""
+    """Return all ``out.{ident}[.{release}].json`` files in *directory*."""
     results = []
     if not directory.is_dir():
         return results
@@ -171,21 +181,47 @@ def _existing_out_versions(directory: Path, cycle: AiracCycle) -> list[Path]:
         m = _OUT_VERSION_RE.match(p.name)
         if m and m.group(1) == cycle.ident:
             results.append(p)
-    return sorted(results, key=lambda p: int(_OUT_VERSION_RE.match(p.name).group(2)))
+    return sorted(
+        results,
+        key=lambda p: (
+            -1 if _OUT_VERSION_RE.match(p.name).group(2) is None
+            else int(_OUT_VERSION_RE.match(p.name).group(2))
+        ),
+    )
 
 
 def _next_out_version(directory: Path, cycle: AiracCycle) -> int:
-    """Return the next version number for ``out.{ident}.{n}.json`` in *directory*."""
+    """Return the next legacy archive sequence number for compatibility callers."""
     existing = _existing_out_versions(directory, cycle)
-    if not existing:
+    numbered = [p for p in existing if _OUT_VERSION_RE.match(p.name).group(2)]
+    if not numbered:
         return 1
-    last_n = int(_OUT_VERSION_RE.match(existing[-1].name).group(2))
+    last_n = int(_OUT_VERSION_RE.match(numbered[-1].name).group(2))
     return last_n + 1
+
+
+def _out_cycle_value(path: Path, cycle: AiracCycle) -> str:
+    """Read and validate the parser cycle value from *path*."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ArchiverError(f"out.json is not valid JSON: {path}") from exc
+
+    cycle_value = payload.get("cycle")
+    if not isinstance(cycle_value, str):
+        raise ArchiverError(f"out.json is missing string cycle field: {path}")
+    if not _OUT_CYCLE_RE.match(cycle_value):
+        raise ArchiverError(f"Invalid out.json cycle value: {cycle_value!r}")
+    if cycle_value.split(".", 1)[0] != cycle.ident:
+        raise ArchiverError(
+            f"out.json cycle {cycle_value!r} does not match archive cycle {cycle.ident!r}"
+        )
+    return cycle_value
 
 
 def _is_allowed(path: Path, allowed_names: set[str]) -> bool:
     """Return True if *path*'s filename is in the allowlist."""
-    return path.name in allowed_names
+    return path.name in allowed_names or bool(_CURATION_AUDIT_RE.match(path.name))
 
 
 def _collect_files(cycle_dir: Path, cycle: AiracCycle) -> tuple[list[Path], list[str]]:
@@ -359,8 +395,9 @@ def archive_cycle(
     files that are absent, writes a manifest with SHA256 checksums, copies
     everything into ``{archive_repo}/vFPC {ident}/``, and runs ``git add``.
 
-    ``out.json`` is renamed to ``out.{ident}.{n}.json`` where *n* increments
-    on each archive run.  Previous versions are preserved across re-archives.
+    ``out.json`` is renamed to match its embedded parser cycle value, for
+    example ``out.2605.9.json``. Previous versions are preserved across
+    re-archives.
 
     Args:
         cycle:        The target AIRAC cycle.
@@ -377,9 +414,21 @@ def archive_cycle(
     """
     files, warnings = _collect_files(cycle_dir, cycle)
 
-    subdir = archive_repo / _archive_dir_name(cycle)
+    source_out = next((p for p in files if p.name == "out.json"), None)
+    has_out = source_out is not None
+    out_version_name: str | None = None
+    if has_out:
+        out_version_name = _out_version_name(_out_cycle_value(source_out, cycle))
 
-    # Preserve previously-archived out.{ident}.{n}.json versions by moving
+    subdir = archive_repo / _archive_dir_name(cycle)
+    if out_version_name is not None:
+        existing_out = subdir / out_version_name
+        if existing_out.exists() and _sha256(source_out) != _sha256(existing_out):
+            raise ArchiverError(
+                f"Archived parser output already exists with different content: {existing_out}"
+            )
+
+    # Preserve previously-archived out.{ident}[.{release}].json versions by moving
     # them to a temp directory on the same filesystem, then restoring after
     # rmtree.  This avoids holding file contents in RAM and minimises the
     # window where data is absent from both locations.
@@ -401,24 +450,21 @@ def archive_cycle(
             shutil.move(str(p), str(subdir / p.name))
         tmp_hold.rmdir()
 
-    # Determine the next version number for out.json and prepare the rename.
-    # _copy_files copies everything flat, so we handle the rename afterwards.
-    has_out = any(p.name == "out.json" for p in files)
     out_version_path: Path | None = None
-    if has_out:
-        version_n = _next_out_version(subdir, cycle)
-        out_version_name = _out_version_name(cycle, version_n)
 
     manifest_path = subdir / "manifest.md"
 
     # Copy source files into the archive subdir
     copied = _copy_files(files, subdir)
 
-    # Rename out.json → out.{ident}.{n}.json
+    # Rename out.json to the parser cycle release filename.
     if has_out:
         old_out = subdir / "out.json"
         out_version_path = subdir / out_version_name
-        old_out.rename(out_version_path)
+        if out_version_path.exists():
+            old_out.unlink()
+        else:
+            old_out.rename(out_version_path)
         copied = [out_version_path if p.name == "out.json" else p for p in copied]
 
     # Collect all out versions (preserved + new) for the manifest

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -22,6 +22,7 @@ from src.archiver import (
     _git_stage,
     _is_allowed,
     _next_out_version,
+    _out_cycle_value,
     _out_version_name,
     _sha256,
     _sct_basename,
@@ -60,6 +61,10 @@ _OPTIONAL_ALLOWED_FILES = [
     "procedure_facts.json",
     "restricted_area_facts.json",
     "manifest.json",
+    "Routes.city_pair_cap_edits.20260522-082432.json",
+    "Routes.confirmed_rad_denial_curation.20260608-071406.json",
+    "Routes.vfp60_eg2444_curation.20260529-163336.md",
+    "vfp60_eg2444_route_curation.json",
 ]
 
 # Files that should be silently ignored (not on the allowlist).
@@ -72,6 +77,8 @@ _NON_ALLOWED_FILES = [
     "What's changed.csv",
     "log_20260219_0900.txt",
     "discord_announcement.md",
+    "Routes.csv.pre-2605.9-confirmed-rad-denial-curation.20260608-071406.bak",
+    "out.json.pre-2605.9-confirmed-rad-denial-curation.20260608-071645.bak",
 ]
 
 
@@ -81,7 +88,10 @@ def _make_cycle_dir(tmp_path: Path, filenames: list[str]) -> Path:
     cycle_dir.mkdir()
     for name in filenames:
         p = cycle_dir / name
-        p.write_text(f"content of {name}", encoding="utf-8")
+        if name == "out.json":
+            p.write_text('{"cycle": "2602.1", "airports": [], "constraints": []}', encoding="utf-8")
+        else:
+            p.write_text(f"content of {name}", encoding="utf-8")
     return cycle_dir
 
 
@@ -126,13 +136,20 @@ class TestSctBasename:
 
 class TestOutVersionName:
     def test_format(self):
-        assert _out_version_name(CYCLE_2602, 1) == "out.2602.1.json"
+        assert _out_version_name("2602.1") == "out.2602.1.json"
 
     def test_double_digit_version(self):
-        assert _out_version_name(CYCLE_2602, 12) == "out.2602.12.json"
+        assert _out_version_name("2602.12") == "out.2602.12.json"
 
     def test_different_cycle(self):
-        assert _out_version_name(CYCLE_2601, 3) == "out.2601.3.json"
+        assert _out_version_name("2601.3") == "out.2601.3.json"
+
+    def test_base_cycle(self):
+        assert _out_version_name("2602") == "out.2602.json"
+
+    def test_rejects_invalid_cycle_value(self):
+        with pytest.raises(ArchiverError, match="Invalid out.json cycle value"):
+            _out_version_name("2602-beta")
 
 
 class TestOutVersionRE:
@@ -144,6 +161,11 @@ class TestOutVersionRE:
         assert m.group(1) == "2603"
         assert m.group(2) == "5"
 
+    def test_matches_base_cycle_name(self):
+        m = _OUT_VERSION_RE.match("out.2603.json")
+        assert m.group(1) == "2603"
+        assert m.group(2) is None
+
     def test_rejects_plain_out_json(self):
         assert not _OUT_VERSION_RE.match("out.json")
 
@@ -152,6 +174,37 @@ class TestOutVersionRE:
 
     def test_rejects_wrong_prefix(self):
         assert not _OUT_VERSION_RE.match("data.2602.1.json")
+
+
+class TestOutCycleValue:
+    def test_reads_cycle_from_parser_output(self, tmp_path):
+        path = tmp_path / "out.json"
+        path.write_text('{"cycle": "2602.9"}', encoding="utf-8")
+        assert _out_cycle_value(path, CYCLE_2602) == "2602.9"
+
+    def test_rejects_missing_cycle(self, tmp_path):
+        path = tmp_path / "out.json"
+        path.write_text("{}", encoding="utf-8")
+        with pytest.raises(ArchiverError, match="missing string cycle"):
+            _out_cycle_value(path, CYCLE_2602)
+
+    def test_rejects_non_string_cycle(self, tmp_path):
+        path = tmp_path / "out.json"
+        path.write_text('{"cycle": 2602}', encoding="utf-8")
+        with pytest.raises(ArchiverError, match="missing string cycle"):
+            _out_cycle_value(path, CYCLE_2602)
+
+    def test_rejects_invalid_json(self, tmp_path):
+        path = tmp_path / "out.json"
+        path.write_text("not json at all", encoding="utf-8")
+        with pytest.raises(ArchiverError, match="not valid JSON"):
+            _out_cycle_value(path, CYCLE_2602)
+
+    def test_rejects_mismatched_cycle(self, tmp_path):
+        path = tmp_path / "out.json"
+        path.write_text('{"cycle": "2601.9"}', encoding="utf-8")
+        with pytest.raises(ArchiverError, match="does not match archive cycle"):
+            _out_cycle_value(path, CYCLE_2602)
 
 
 class TestExistingOutVersions:
@@ -260,6 +313,25 @@ class TestIsAllowed:
     def test_audit_md_not_allowed(self):
         allowed = set(_ALLOWED_FIXED) | {"UK_2026_02.sct"}
         assert not _is_allowed(Path("audit_decisions.md"), allowed)
+
+    def test_route_curation_json_allowed(self):
+        allowed = set(_ALLOWED_FIXED) | {"UK_2026_02.sct"}
+        assert _is_allowed(Path("Routes.confirmed_rad_denial_curation.20260608-071406.json"), allowed)
+
+    def test_route_edit_json_allowed(self):
+        allowed = set(_ALLOWED_FIXED) | {"UK_2026_02.sct"}
+        assert _is_allowed(Path("Routes.city_pair_cap_edits.20260522-082432.json"), allowed)
+
+    def test_vfp_curation_json_allowed(self):
+        allowed = set(_ALLOWED_FIXED) | {"UK_2026_02.sct"}
+        assert _is_allowed(Path("vfp60_eg2444_route_curation.json"), allowed)
+
+    def test_route_backup_not_allowed(self):
+        allowed = set(_ALLOWED_FIXED) | {"UK_2026_02.sct"}
+        assert not _is_allowed(
+            Path("Routes.csv.pre-2605.9-confirmed-rad-denial-curation.20260608-071406.bak"),
+            allowed,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -674,8 +746,8 @@ class TestArchiveCycle:
         assert not (subdir / "out.json").exists(), "bare out.json must not remain"
         assert (subdir / "out.2602.1.json").exists()
 
-    def test_out_version_increments_on_rearchive(self, tmp_path):
-        """Re-archiving must create out.{ident}.2.json and preserve version 1."""
+    def test_out_version_uses_parser_cycle_on_rearchive(self, tmp_path):
+        """Re-archiving uses the parser output cycle rather than local sequence."""
         cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES)
         archive_repo = tmp_path / "airac-data"
         archive_repo.mkdir()
@@ -685,42 +757,74 @@ class TestArchiveCycle:
         subdir = archive_repo / "vFPC 2602"
         assert (subdir / "out.2602.1.json").exists()
 
-        (cycle_dir / "out.json").write_text("updated content", encoding="utf-8")
+        (cycle_dir / "out.json").write_text('{"cycle": "2602.7", "constraints": []}', encoding="utf-8")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
         assert (subdir / "out.2602.1.json").exists(), "version 1 must be preserved"
-        assert (subdir / "out.2602.2.json").exists(), "version 2 must be created"
-        assert (subdir / "out.2602.1.json").read_text() == "content of out.json"
-        assert (subdir / "out.2602.2.json").read_text() == "updated content"
+        assert (subdir / "out.2602.7.json").exists(), "parser release 7 must be created"
 
-    def test_out_version_preserved_contents_across_three_runs(self, tmp_path):
-        """Three archive runs should produce out.2602.{1,2,3}.json with correct contents."""
+    def test_out_version_preserved_contents_across_three_parser_releases(self, tmp_path):
+        """Archive runs should preserve each parser release named by out.json."""
         cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES)
         archive_repo = tmp_path / "airac-data"
         archive_repo.mkdir()
         subdir = archive_repo / "vFPC 2602"
 
-        for i in range(1, 4):
-            (cycle_dir / "out.json").write_text(f"version {i}", encoding="utf-8")
+        for i in (1, 4, 9):
+            (cycle_dir / "out.json").write_text(f'{{"cycle": "2602.{i}", "release": {i}}}', encoding="utf-8")
             with patch("subprocess.run") as mock_run:
                 mock_run.return_value.returncode = 0
                 archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
 
-        for i in range(1, 4):
+        for i in (1, 4, 9):
             p = subdir / f"out.2602.{i}.json"
             assert p.exists(), f"version {i} must exist"
-            assert p.read_text() == f"version {i}"
+            assert f'"cycle": "2602.{i}"' in p.read_text()
 
-    def test_manifest_lists_all_out_versions(self, tmp_path):
-        """Manifest after re-archive must list both out versions."""
+    def test_rearchive_same_parser_release_with_different_content_raises(self, tmp_path):
+        """A parser release filename cannot be overwritten with different content."""
         cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES)
         archive_repo = tmp_path / "airac-data"
         archive_repo.mkdir()
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
-        (cycle_dir / "out.json").write_text("v2", encoding="utf-8")
+
+        (cycle_dir / "out.json").write_text('{"cycle": "2602.1", "changed": true}', encoding="utf-8")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            with pytest.raises(ArchiverError, match="already exists with different content"):
+                archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
+
+    def test_rearchive_same_parser_release_with_same_content_succeeds(self, tmp_path):
+        """Re-running the same parser release with identical content is idempotent."""
+        cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES)
+        archive_repo = tmp_path / "airac-data"
+        archive_repo.mkdir()
+        subdir = archive_repo / "vFPC 2602"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
+
+        first_content = (subdir / "out.2602.1.json").read_text(encoding="utf-8")
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
+
+        assert not (subdir / "out.json").exists()
+        assert (subdir / "out.2602.1.json").read_text(encoding="utf-8") == first_content
+
+    def test_manifest_lists_all_out_versions(self, tmp_path):
+        """Manifest after re-archive must list both parser release outputs."""
+        cycle_dir = _make_cycle_dir(tmp_path, _ALLOWED_FILES)
+        archive_repo = tmp_path / "airac-data"
+        archive_repo.mkdir()
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            archive_cycle(CYCLE_2602, cycle_dir, archive_repo)
+        (cycle_dir / "out.json").write_text('{"cycle": "2602.2"}', encoding="utf-8")
         with patch("subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             _, manifest_path = archive_cycle(CYCLE_2602, cycle_dir, archive_repo)


### PR DESCRIPTION
## Summary
- name archived out.json from the embedded parser cycle value, e.g. out.2605.9.json
- preserve prior out.YYNN.N.json files and reject same-release overwrites with different content
- allowlist route curation evidence files needed to reconstruct SRD route patches
- update docs and tests for the new dot-release contract

## Verification
- python -m pytest: 181 passed, 2 skipped